### PR TITLE
Add support for "!has" filter in style expressions

### DIFF
--- a/src/compat/json_style.ts
+++ b/src/compat/json_style.ts
@@ -25,6 +25,8 @@ export function filterFn(arr:any[]):((f:any)=>boolean) {
         return f => !arr.slice(2,arr.length).includes(f[arr[1]])
     } else if (arr[0] === "has") {
         return f => f.hasOwnProperty(arr[1])
+    } else if (arr[0] === "!has") {
+        return f => !f.hasOwnProperty(arr[1])
     } else if (arr[0] === "all") {
         let parts = arr.slice(1,arr.length).map(e => filterFn(e))
         return f => parts.every(p => { return p(f)})

--- a/test/json_style.test.ts
+++ b/test/json_style.test.ts
@@ -49,6 +49,11 @@ test("has",async () => {
     assert(f({"type":"foo"}))
     assert(!f({}))
 })
+test("!has",async () => {
+    let f = filterFn(['!has','type'])
+    assert(!f({"type":"foo"}))
+    assert(f({}))
+})
 test("!",async () => {
     let f = filterFn(["!",['has','type']])
     assert(!f({"type":"foo"}))


### PR DESCRIPTION
Increase support of the Mapbox-GL style format by adding `!has` to the supported filter functions.
It's defined as the opposite operator to "has", much like there is "in" and "!in".

Here is the link to the Mapbox-GL style spec https://github.com/mapbox/mapbox-gl-js/blob/main/src/style-spec/reference/v8.json#L2542-L2544