### PR TITLE
Add `text-field` layout prop to json_style

### DIFF
--- a/src/compat/json_style.ts
+++ b/src/compat/json_style.ts
@@ -209,7 +209,8 @@ export function json_style(obj:any,fontsubmap:Map<string,FontSub>) {
                         fill:layer.paint['text-color'],
                         width:layer.paint['text-halo-width'],
                         stroke:layer.paint['text-halo-color'],
-                        textTransform:layer.layout["text-transform"]
+                        textTransform:layer.layout["text-transform"],
+                        properties:layer.layout["text-field"] ? [layer.layout["text-field"]] : undefined
                     })
                 })
             } else {
@@ -221,7 +222,8 @@ export function json_style(obj:any,fontsubmap:Map<string,FontSub>) {
                         fill: layer.paint['text-color'],
                         stroke: layer.paint['text-halo-color'],
                         width:layer.paint['text-halo-width'],
-                        textTransform:layer.layout["text-transform"]
+                        textTransform:layer.layout["text-transform"],
+                        properties:layer.layout["text-field"] ? [layer.layout["text-field"]] : undefined
                     })
                 })
             }


### PR DESCRIPTION
Add `text-field` layout prop to json_style. This can be used to set which feature property is used as the label. 

It follows mapbox style-spec https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-text-field

