### PR TITLE
Add feature propterty to filter function

### DIFF
--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -5,6 +5,7 @@ import { Zxy, toIndex, Bbox } from './tilecache'
 // @ts-ignore
 import RBush from 'rbush'
 import { LabelSymbolizer } from './symbolizer'
+import { Filter } from './painter'
 
 type TileInvalidationCallback = (tiles:Set<string>)=>void
 
@@ -35,7 +36,7 @@ export interface LabelRule {
     maxzoom?:number
     dataLayer:string 
     symbolizer: LabelSymbolizer
-    filter?:(properties:any)=>boolean
+    filter?:Filter
     visible?:boolean
     sort?:(a:any,b:any)=>number
 }
@@ -218,7 +219,7 @@ export class Labeler {
                 order:order
             }
             for (let feature of feats) {
-                if (rule.filter && !rule.filter(feature.properties)) continue
+                if (rule.filter && !rule.filter(feature.properties, feature)) continue
                 let transformed = transformGeom(feature.geom,pt.scale,pt.origin)
                 let labels = rule.symbolizer.place(layout, transformed,feature)
                 if (!labels) continue

--- a/src/painter.ts
+++ b/src/painter.ts
@@ -1,9 +1,11 @@
 // @ts-ignore
 import Point from '@mapbox/point-geometry'
-import { Zxy, Bbox } from './tilecache'
+import { Zxy, Bbox, Feature } from './tilecache'
 import { PreparedTile, transformGeom } from './view'
 import { PaintSymbolizer } from './symbolizer'
 import { Index } from './labeler'
+
+export type Filter = (properties: any, feature?: Feature) => boolean
 
 export interface Rule {
     id?:string
@@ -11,7 +13,7 @@ export interface Rule {
     maxzoom:number
     dataLayer: string
     symbolizer: PaintSymbolizer
-    filter?(properties:any): boolean
+    filter?:Filter
 }
 
 export function painter(ctx:any,prepared_tiles:PreparedTile[],label_data:Index,rules:Rule[],bbox:Bbox,origin:Point,clip:boolean,debug:string) {
@@ -54,7 +56,7 @@ export function painter(ctx:any,prepared_tiles:PreparedTile[],label_data:Index,r
                     continue
                 }
                 let properties = feature.properties
-                if (rule.filter && !rule.filter(properties)) continue
+                if (rule.filter && !rule.filter(properties, feature)) continue
                 if (ps != 1) {
                     geom = transformGeom(geom,ps, new Point(0,0))
                 }


### PR DESCRIPTION
Add feature propterty to filter function. This means that we can filter rules by feature attributes other than `properties`. For example `geomType` or `bbox`