### PR TITLE
Add some types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
       "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
       "dev": true,
+      "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       }
@@ -107,6 +108,9 @@
       },
       "bin": {
         "esr": "bin/esr.js"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
       }
     },
     "node_modules/esbuild-runner/node_modules/tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "rbush": "^3.0.1"
       },
       "devDependencies": {
+        "@types/baretest": "^2.0.0",
+        "@types/node": "^16.11.1",
         "baretest": "^2.0.0",
         "esbuild": "^0.12.15",
         "esbuild-runner": "^2.2.0",
@@ -46,6 +48,18 @@
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
+    },
+    "node_modules/@types/baretest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/baretest/-/baretest-2.0.0.tgz",
+      "integrity": "sha512-Yd+47uRtX/4No0alCNnnzICDR7aO6GNfyqjAHmAwwZyH/Cht0WOZnnxao83M1W9utce5aPZhtQvdpvIFIJkniw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
+      "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==",
+      "dev": true
     },
     "node_modules/barecolor": {
       "version": "1.0.1",
@@ -78,7 +92,6 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
       "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
       "dev": true,
-      "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       }
@@ -94,9 +107,6 @@
       },
       "bin": {
         "esr": "bin/esr.js"
-      },
-      "peerDependencies": {
-        "esbuild": "*"
       }
     },
     "node_modules/esbuild-runner/node_modules/tslib": {
@@ -113,21 +123,7 @@
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "node_modules/pbf": {
       "version": "3.2.1",
@@ -259,6 +255,18 @@
       "requires": {
         "@mapbox/point-geometry": "~0.1.0"
       }
+    },
+    "@types/baretest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/baretest/-/baretest-2.0.0.tgz",
+      "integrity": "sha512-Yd+47uRtX/4No0alCNnnzICDR7aO6GNfyqjAHmAwwZyH/Cht0WOZnnxao83M1W9utce5aPZhtQvdpvIFIJkniw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.1.tgz",
+      "integrity": "sha512-PYGcJHL9mwl1Ek3PLiYgyEKtwTMmkMw4vbiyz/ps3pfdRYLVv+SN7qHVAImrjdAXxgluDEw6Ph4lyv+m9UpRmA==",
+      "dev": true
     },
     "barecolor": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "devDependencies": {
+    "@types/baretest": "^2.0.0",
+    "@types/node": "^16.11.1",
     "baretest": "^2.0.0",
     "esbuild": "^0.12.15",
     "esbuild-runner": "^2.2.0",

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -161,12 +161,12 @@ export class FontAttr {
   }
 }
 
-export class ArrayAttr<T = string> {
-  value: T[] | ((z: number, f?: Feature) => T[]);
+export class ArrayAttr<T = number> {
+  value: AttrOption<T[]>;
   per_feature: boolean;
 
-  constructor(c: any, defaultValue: number[] = []) {
-    this.value = c || defaultValue;
+  constructor(c: AttrOption<T[]>, defaultValue: T[] = []) {
+    this.value = c ?? defaultValue;
     this.per_feature =
       typeof this.value == "function" && this.value.length == 2;
   }

--- a/src/attribute.ts
+++ b/src/attribute.ts
@@ -1,16 +1,18 @@
 import { Feature } from "./tilecache";
 
-export class StringAttr {
-  str: string | ((z: number, f?: Feature) => string);
+export type AttrOption<T> = T | ((z: number, f?: Feature) => T);
+
+export class StringAttr<T extends string = string> {
+  str: AttrOption<T>;
   per_feature: boolean;
 
-  constructor(c: any, defaultValue: string = "") {
-    this.str = c || defaultValue;
+  constructor(c: AttrOption<T> | undefined, defaultValue: T) {
+    this.str = c ?? defaultValue;
     this.per_feature = typeof this.str == "function" && this.str.length == 2;
   }
 
-  public get(z: number, f?: Feature): string {
-    if (typeof this.str == "function") {
+  public get(z: number, f?: Feature): T {
+    if (typeof this.str === "function") {
       return this.str(z, f);
     } else {
       return this.str;
@@ -19,11 +21,11 @@ export class StringAttr {
 }
 
 export class NumberAttr {
-  value: number | ((z: number, f?: Feature) => number);
+  value: AttrOption<number>;
   per_feature: boolean;
 
-  constructor(c: any, defaultValue: number = 1) {
-    this.value = c || defaultValue;
+  constructor(c: AttrOption<number> | undefined, defaultValue: number = 1) {
+    this.value = c ?? defaultValue;
     this.per_feature =
       typeof this.value == "function" && this.value.length == 2;
   }
@@ -37,27 +39,35 @@ export class NumberAttr {
   }
 }
 
-export class TextAttr {
-  label_props: string[] | ((z: number, f?: Feature) => string[]);
-  textTransform: string | ((z: number, f?: Feature) => string);
+export interface TextAttrOptions {
+  label_props?: AttrOption<string[]>;
+  textTransform?: AttrOption<string>;
+}
 
-  constructor(options: any = {}) {
-    this.label_props = options.label_props || ["name"];
-    this.textTransform = options.textTransform;
+export class TextAttr {
+  label_props: AttrOption<string[]>;
+  textTransform?: AttrOption<string>;
+
+  constructor(options?: TextAttrOptions) {
+    this.label_props = options?.label_props ?? ["name"];
+    this.textTransform = options?.textTransform;
   }
 
-  public get(z: number, f: Feature): string {
-    var retval;
+  public get(z: number, f: Feature): string | undefined {
+    let retval: string | undefined;
 
-    var label_props: string[];
+    let label_props: string[];
     if (typeof this.label_props == "function") {
       label_props = this.label_props(z, f);
     } else {
       label_props = this.label_props;
     }
     for (let property of label_props) {
-      if (f.props.hasOwnProperty(property)) {
-        retval = f.props[property];
+      if (
+        f.props.hasOwnProperty(property) &&
+        typeof f.props[property] === "string"
+      ) {
+        retval = f.props[property] as string;
         break;
       }
     }
@@ -80,25 +90,33 @@ export class TextAttr {
   }
 }
 
-export class FontAttr {
-  family?: string | ((z: number, f: Feature) => string);
-  size?: number | ((z: number, f: Feature) => number);
-  weight?: number | ((z: number, f: Feature) => number);
-  style?: number | ((z: number, f: Feature) => string);
-  font?: string | ((z: number, f: Feature) => string);
+export interface FontAttrOptions {
+  font?: AttrOption<string>;
+  fontFamily?: AttrOption<string>;
+  fontSize?: AttrOption<number>;
+  fontWeight?: AttrOption<number>;
+  fontStyle?: AttrOption<string>;
+}
 
-  constructor(options: any) {
-    if (options.font) {
+export class FontAttr {
+  family?: AttrOption<string>;
+  size?: AttrOption<number>;
+  weight?: AttrOption<number>;
+  style?: AttrOption<string>;
+  font?: AttrOption<string>;
+
+  constructor(options?: FontAttrOptions) {
+    if (options?.font) {
       this.font = options.font;
     } else {
-      this.family = options.fontFamily || "sans-serif";
-      this.size = options.fontSize || 12;
-      this.weight = options.fontWeight;
-      this.style = options.fontStyle;
+      this.family = options?.fontFamily ?? "sans-serif";
+      this.size = options?.fontSize ?? 12;
+      this.weight = options?.fontWeight;
+      this.style = options?.fontStyle;
     }
   }
 
-  public get(z: number, f: Feature) {
+  public get(z: number, f?: Feature) {
     if (this.font) {
       if (typeof this.font === "function") {
         return this.font(z, f);
@@ -143,11 +161,8 @@ export class FontAttr {
   }
 }
 
-export class ArrayAttr {
-  value:
-    | string[]
-    | number[]
-    | ((z: number, f?: Feature) => string[] | number[]);
+export class ArrayAttr<T = string> {
+  value: T[] | ((z: number, f?: Feature) => T[]);
   per_feature: boolean;
 
   constructor(c: any, defaultValue: number[] = []) {
@@ -156,7 +171,7 @@ export class ArrayAttr {
       typeof this.value == "function" && this.value.length == 2;
   }
 
-  public get(z: number, f?: Feature): string[] | number[] {
+  public get(z: number, f?: Feature): T[] {
     if (typeof this.value == "function") {
       return this.value(z, f);
     } else {

--- a/src/default_style/style.ts
+++ b/src/default_style/style.ts
@@ -1,25 +1,21 @@
-import {
-  createPattern,
-  PolygonSymbolizer,
-  IconSymbolizer,
-  ShieldSymbolizer,
-  LineSymbolizer,
-  CenteredTextSymbolizer,
-  OffsetTextSymbolizer,
-  GroupSymbolizer,
-  FlexSymbolizer,
-  CircleSymbolizer,
-  PolygonLabelSymbolizer,
-  LineLabelSymbolizer,
-  exp,
-  LabelSymbolizer,
-  Padding,
-  Justify,
-} from "../symbolizer";
-import { Rule } from "../painter";
-import { LabelRule } from "../labeler";
-import { Feature } from "../tilecache";
 import { hsla, parseToHsla } from "color2k";
+import { LabelRule } from "../labeler";
+import { Rule } from "../painter";
+import {
+  CenteredTextSymbolizer,
+  CircleSymbolizer,
+  exp,
+  FlexSymbolizer,
+  GroupSymbolizer,
+  LabelSymbolizer,
+  LineLabelSymbolizer,
+  LineSymbolizer,
+  OffsetTextSymbolizer,
+  PolygonLabelSymbolizer,
+  PolygonSymbolizer,
+  ShieldSymbolizer,
+} from "../symbolizer";
+import { Feature } from "../tilecache";
 
 export interface DefaultStyleParams {
   earth: string;
@@ -333,27 +329,21 @@ export const labelRules = (
   let languageStack = (symbolizer: LabelSymbolizer, fill: string) => {
     if (!language2) return symbolizer;
     if (symbolizer instanceof OffsetTextSymbolizer) {
-      return new FlexSymbolizer(
-        [
-          symbolizer,
-          new OffsetTextSymbolizer({
-            fill: fill,
-            label_props: language2,
-          }),
-        ],
-        {}
-      );
+      return new FlexSymbolizer([
+        symbolizer,
+        new OffsetTextSymbolizer({
+          fill: fill,
+          label_props: language2,
+        }),
+      ]);
     } else {
-      return new FlexSymbolizer(
-        [
-          symbolizer,
-          new CenteredTextSymbolizer({
-            fill: fill,
-            label_props: language2,
-          }),
-        ],
-        {}
-      );
+      return new FlexSymbolizer([
+        symbolizer,
+        new CenteredTextSymbolizer({
+          fill: fill,
+          label_props: language2,
+        }),
+      ]);
     }
   };
 
@@ -365,7 +355,7 @@ export const labelRules = (
           label_props: nametags,
           fill: params.countryLabel,
           lineHeight: 1.5,
-          font: (z: number, f: Feature) => {
+          font: (z: number, f?: Feature) => {
             if (z < 6) return "200 14px sans-serif";
             return "200 20px sans-serif";
           },
@@ -402,8 +392,8 @@ export const labelRules = (
         new CenteredTextSymbolizer({
           label_props: nametags,
           fill: params.cityLabel,
-          font: (z: number, f: Feature) => {
-            if (f.props["pmap:rank"] == 1) {
+          font: (z: number, f?: Feature) => {
+            if (f?.props["pmap:rank"] === 1) {
               if (z > 8) return "600 20px sans-serif";
               return "600 12px sans-serif";
             } else {
@@ -434,9 +424,10 @@ export const labelRules = (
           new OffsetTextSymbolizer({
             label_props: nametags,
             fill: params.cityLabel,
-            offset: 2,
-            font: (z: number, f: Feature) => {
-              if (f.props["pmap:rank"] == 1) {
+            offsetX: 2,
+            offsetY: 2,
+            font: (z: number, f?: Feature) => {
+              if (f?.props["pmap:rank"] === 1) {
                 if (z > 8) return "600 20px sans-serif";
                 return "600 12px sans-serif";
               } else {
@@ -537,7 +528,8 @@ export const labelRules = (
           new OffsetTextSymbolizer({
             label_props: nametags,
             fill: params.poisLabel,
-            offset: 2,
+            offsetX: 2,
+            offsetY: 2,
             font: "300 10px sans-serif",
           }),
           params.poisLabel

--- a/src/frontends/leaflet.ts
+++ b/src/frontends/leaflet.ts
@@ -50,7 +50,7 @@ const timer = (duration: number) => {
 // replacement for Promise.allSettled (requires ES2020+)
 // this is called for every tile render,
 // so ensure font loading failure does not make map rendering fail
-const reflect = (promise:Promise<any>) => {
+const reflect = (promise: Promise<any>) => {
   return promise.then(
     (v) => {
       return { status: "fulfilled", value: v };
@@ -146,7 +146,7 @@ const leafletLayer = (options: any): any => {
       try {
         prepared_tile = await this.view.getDisplayTile(coords);
       } catch (e) {
-        if (e.name == "AbortError") return;
+        if ((e as any).name == "AbortError") return;
         else throw e;
       }
 

--- a/src/labeler.ts
+++ b/src/labeler.ts
@@ -1,11 +1,11 @@
 // @ts-ignore
 import Point from "@mapbox/point-geometry";
-import { PreparedTile, transformGeom } from "./view";
-import { Zxy, toIndex, Bbox } from "./tilecache";
 // @ts-ignore
 import RBush from "rbush";
-import { LabelSymbolizer, DrawExtra } from "./symbolizer";
 import { Filter } from "./painter";
+import { DrawExtra, LabelSymbolizer } from "./symbolizer";
+import { Bbox, toIndex } from "./tilecache";
+import { PreparedTile, transformGeom } from "./view";
 
 type TileInvalidationCallback = (tiles: Set<string>) => void;
 
@@ -15,7 +15,7 @@ type TileInvalidationCallback = (tiles: Set<string>) => void;
 export interface Label {
   anchor: Point;
   bboxes: Bbox[];
-  draw: (ctx: any, drawExtra?: DrawExtra) => void;
+  draw: (ctx: CanvasRenderingContext2D, drawExtra?: DrawExtra) => void;
   deduplicationKey?: string;
   deduplicationDistance?: number;
 }
@@ -23,7 +23,7 @@ export interface Label {
 export interface IndexedLabel {
   anchor: Point;
   bboxes: Bbox[];
-  draw: (ctx: any) => void;
+  draw: (ctx: CanvasRenderingContext2D) => void;
   order: number;
   tileKey: string;
   deduplicationKey?: string;
@@ -81,7 +81,7 @@ export const covering = (
 };
 
 export class Index {
-  tree: RBush;
+  tree: RBush<any>;
   current: Map<string, Set<IndexedLabel>>;
   dim: number;
 
@@ -306,7 +306,7 @@ export class Labeler {
         zoom: this.z,
         scratch: this.scratch,
         order: order,
-        overzoom: this.z - pt.data_tile.z
+        overzoom: this.z - pt.data_tile.z,
       };
       for (let feature of feats) {
         if (rule.filter && !rule.filter(this.z, feature)) continue;
@@ -450,7 +450,7 @@ export class Labelers {
     }
   }
 
-  public getIndex(z: number): RBush {
+  public getIndex(z: number) {
     let labeler = this.labelers.get(z);
     if (labeler) return labeler.index; // TODO cleanup
   }

--- a/src/tilecache.ts
+++ b/src/tilecache.ts
@@ -7,6 +7,18 @@ import Protobuf from "pbf";
 // @ts-ignore
 import { PMTiles } from "pmtiles";
 
+export type JsonValue =
+  | boolean
+  | number
+  | string
+  | null
+  | JsonArray
+  | JsonObject;
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+export interface JsonArray extends Array<JsonValue> {}
+
 export enum GeomType {
   Point = 1,
   Line = 2,
@@ -21,7 +33,7 @@ export interface Bbox {
 }
 
 export interface Feature {
-  readonly props: any;
+  readonly props: JsonObject;
   readonly bbox: Bbox;
   readonly geomType: GeomType;
   readonly geom: Point[][];

--- a/test/attribute.test.ts
+++ b/test/attribute.test.ts
@@ -1,28 +1,29 @@
-import {
-  NumberAttr,
-  StringAttr,
-  FontAttr,
-  TextAttr,
-  ArrayAttr,
-} from "../src/attribute";
-import { GeomType } from "../src/tilecache";
 import assert from "assert";
 import baretest from "baretest";
+import {
+  ArrayAttr,
+  FontAttr,
+  NumberAttr,
+  StringAttr,
+  TextAttr,
+} from "../src/attribute";
+import { GeomType } from "../src/tilecache";
+import { emptyFeature } from "./json_style.test";
 
-test = baretest("Attribute");
+const test = baretest("Attribute");
 
 test("numberattr", async () => {
   let n = new NumberAttr(undefined, undefined);
-  assert.equal(n.get(), 1);
+  assert.equal(n.get(1), 1);
 
   n = new NumberAttr(2, undefined);
-  assert.equal(n.get(), 2);
+  assert.equal(n.get(1), 2);
 
   n = new NumberAttr(undefined, 3);
-  assert.equal(n.get(), 3);
+  assert.equal(n.get(1), 3);
 
   n = new NumberAttr(undefined, 0);
-  assert.equal(n.get(), 0);
+  assert.equal(n.get(1), 0);
 
   n = new NumberAttr((z, f) => {
     return z;
@@ -43,27 +44,27 @@ test("numberattr", async () => {
 });
 
 test("stringattr", async () => {
-  let c = new StringAttr(undefined, undefined);
-  assert.equal(c.get(), "");
+  const c1 = new StringAttr(undefined, "");
+  assert.equal(c1.get(1), "");
 
-  c = new StringAttr(undefined, "red");
-  assert.equal(c.get(), "red");
+  const c2 = new StringAttr(undefined, "red");
+  assert.equal(c2.get(1), "red");
 
-  c = new StringAttr("blue");
-  assert.equal(c.get(), "blue");
+  const c3 = new StringAttr("blue", "green");
+  assert.equal(c3.get(1), "blue");
 
-  c = new StringAttr((z, f) => {
+  const c4 = new StringAttr((z, f) => {
     if (z < 4) return "green";
     return "aquamarine";
-  });
-  assert.equal(c.get(3), "green");
-  assert.equal(c.get(5), "aquamarine");
-  assert.equal(c.per_feature, true);
+  }, undefined);
+  assert.equal(c4.get(3), "green");
+  assert.equal(c4.get(5), "aquamarine");
+  assert.equal(c4.per_feature, true);
 });
 
 test("fontattr", async () => {
   let f = new FontAttr({ font: "12px serif" });
-  assert.equal(f.get(), "12px serif");
+  assert.equal(f.get(1), "12px serif");
 
   f = new FontAttr({
     font: (z) => {
@@ -119,45 +120,51 @@ test("fontattr", async () => {
 
 test("textattr", async () => {
   let t = new TextAttr();
-  assert.equal(
-    t.get(0, { props: { name: "臺北" }, geomType: GeomType.Point }),
-    "臺北"
-  );
+  assert.equal(t.get(0, { ...emptyFeature, props: { name: "臺北" } }), "臺北");
   t = new TextAttr({ label_props: ["name:en"] });
   assert.equal(
     t.get(0, {
+      ...emptyFeature,
       props: { "name:en": "Taipei", name: "臺北" },
-      geomType: GeomType.Point,
     }),
     "Taipei"
   );
   t = new TextAttr({ label_props: ["name:en"], textTransform: "uppercase" });
   assert.equal(
-    t.get(0, { props: { "name:en": "Taipei" }, geomType: GeomType.Point }),
+    t.get(0, { ...emptyFeature, props: { "name:en": "Taipei" } }),
     "TAIPEI"
   );
   t = new TextAttr({ label_props: ["name:en"], textTransform: "lowercase" });
   assert.equal(
-    t.get(0, { props: { "name:en": "Taipei" }, geomType: GeomType.Point }),
+    t.get(0, {
+      ...emptyFeature,
+      props: { "name:en": "Taipei" },
+      geomType: GeomType.Point,
+    }),
     "taipei"
   );
   t = new TextAttr({ label_props: ["name:en"], textTransform: "capitalize" });
   assert.equal(
     t.get(0, {
+      ...emptyFeature,
       props: { "name:en": "from Berga to Taipei" },
       geomType: GeomType.Point,
     }),
     "From Berga To Taipei"
   );
   t = new TextAttr({ label_props: ["name:en"], textTransform: "uppercase" });
-  assert.equal(t.get(0, { props: {} }), undefined);
+  assert.equal(t.get(0, { ...emptyFeature, props: {} }), undefined);
 
   t = new TextAttr({
     label_props: ["name:en"],
     textTransform: (z) => "uppercase",
   });
   assert.equal(
-    t.get(0, { props: { "name:en": "Taipei" }, geomType: GeomType.Point }),
+    t.get(0, {
+      ...emptyFeature,
+      props: { "name:en": "Taipei" },
+      geomType: GeomType.Point,
+    }),
     "TAIPEI"
   );
   t = new TextAttr({
@@ -165,7 +172,11 @@ test("textattr", async () => {
     textTransform: (z) => "lowercase",
   });
   assert.equal(
-    t.get(0, { props: { "name:en": "Taipei" }, geomType: GeomType.Point }),
+    t.get(0, {
+      ...emptyFeature,
+      props: { "name:en": "Taipei" },
+      geomType: GeomType.Point,
+    }),
     "taipei"
   );
   t = new TextAttr({
@@ -174,6 +185,7 @@ test("textattr", async () => {
   });
   assert.equal(
     t.get(0, {
+      ...emptyFeature,
       props: { "name:en": "from Berga to Taipei" },
       geomType: GeomType.Point,
     }),
@@ -187,26 +199,35 @@ test("textattr", async () => {
     },
     textTransform: "uppercase",
   });
-  assert.equal(t.get(0, { props: { name: "台北", abbr: "TPE" } }), "TPE");
-  assert.equal(t.get(9, { props: { name: "台北", abbr: "TPE" } }), "台北");
+  assert.equal(
+    t.get(0, { ...emptyFeature, props: { name: "台北", abbr: "TPE" } }),
+    "TPE"
+  );
+  assert.equal(
+    t.get(9, { ...emptyFeature, props: { name: "台北", abbr: "TPE" } }),
+    "台北"
+  );
 });
 
 test("arrayattr", async () => {
   let n = new ArrayAttr(undefined, undefined);
-  assert.equal(n.get().length, 0);
+  assert.equal(n.get(1).length, 0);
 
   n = new ArrayAttr(2, undefined);
-  assert.equal(n.get(), 2);
+  assert.equal(n.get(1), 2);
 
-  n = new ArrayAttr(undefined, 3);
-  assert.equal(n.get(), 3);
+  n = new ArrayAttr(undefined, [3]);
+  assert.equal(n.get(1)[0], 3);
 
-  n = new ArrayAttr(undefined, 0);
-  assert.equal(n.get(), 0);
+  n = new ArrayAttr(undefined, [0]);
+  assert.equal(n.get(1)[0], 0);
 
-  n = new ArrayAttr((z, f) => {
-    return [z, z];
-  }, 0);
+  n = new ArrayAttr(
+    (z, f) => {
+      return [z, z];
+    },
+    [0]
+  );
   assert.equal(n.get(2)[0], 2);
   assert.equal(n.get(2)[1], 2);
   assert.equal(n.get(3)[0], 3);

--- a/test/attribute.test.ts
+++ b/test/attribute.test.ts
@@ -210,11 +210,11 @@ test("textattr", async () => {
 });
 
 test("arrayattr", async () => {
-  let n = new ArrayAttr(undefined, undefined);
+  let n: ArrayAttr<string> | ArrayAttr<number> = new ArrayAttr([], undefined);
   assert.equal(n.get(1).length, 0);
 
-  n = new ArrayAttr(2, undefined);
-  assert.equal(n.get(1), 2);
+  n = new ArrayAttr<number>([2], undefined);
+  assert.equal(n.get(1)[0], 2);
 
   n = new ArrayAttr(undefined, [3]);
   assert.equal(n.get(1)[0], 3);
@@ -233,14 +233,14 @@ test("arrayattr", async () => {
   assert.equal(n.get(3)[0], 3);
   assert.equal(n.get(3)[1], 3);
 
-  n = new ArrayAttr(1);
+  n = new ArrayAttr([1]);
   assert.equal(n.per_feature, false);
   n = new ArrayAttr((z) => {
-    return z;
+    return [z];
   });
   assert.equal(n.per_feature, false);
   n = new ArrayAttr((z, f) => {
-    return z;
+    return [z];
   });
   assert.equal(n.per_feature, true);
 });

--- a/test/json_style.test.ts
+++ b/test/json_style.test.ts
@@ -1,81 +1,92 @@
-import {
-  filterFn,
-  numberOrFn,
-  numberFn,
-  getFont,
-} from "../src/compat/json_style";
 import assert from "assert";
 import baretest from "baretest";
+import {
+  filterFn,
+  getFont,
+  numberFn,
+  numberOrFn,
+} from "../src/compat/json_style";
+import { Filter } from "../src/painter";
+import { GeomType } from "../src/tilecache";
 
-test = baretest("Json Style");
+const test = baretest("Json Style");
+export const emptyFeature = {
+  props: {},
+  geomType: GeomType.Point,
+  numVertices: 0,
+  geom: [],
+  bbox: { minX: 0, minY: 0, maxX: 0, maxY: 0 },
+};
+
+let f: Filter | undefined;
 
 test("==", async () => {
-  let f = filterFn(["==", "building", "yes"]);
-  assert(f(0, { props: { building: "yes" } }));
+  f = filterFn(["==", "building", "yes"]);
+  assert(f(0, { ...emptyFeature, props: { building: "yes" } }));
 });
 test("!=", async () => {
-  let f = filterFn(["!=", "building", "yes"]);
-  assert(!f(0, { props: { building: "yes" } }));
-  assert(f(0, { props: { building: "no" } }));
+  f = filterFn(["!=", "building", "yes"]);
+  assert(!f(0, { ...emptyFeature, props: { building: "yes" } }));
+  assert(f(0, { ...emptyFeature, props: { building: "no" } }));
 });
 test("<", async () => {
-  let f = filterFn(["<", "level", 3]);
-  assert(f(0, { props: { level: 2 } }));
-  assert(!f(0, { props: { level: 3 } }));
+  f = filterFn(["<", "level", 3]);
+  assert(f(0, { ...emptyFeature, props: { level: 2 } }));
+  assert(!f(0, { ...emptyFeature, props: { level: 3 } }));
 });
 test("<=", async () => {
-  let f = filterFn(["<=", "level", 3]);
-  assert(f(0, { props: { level: 2 } }));
-  assert(f(0, { props: { level: 3 } }));
+  f = filterFn(["<=", "level", 3]);
+  assert(f(0, { ...emptyFeature, props: { level: 2 } }));
+  assert(f(0, { ...emptyFeature, props: { level: 3 } }));
 });
 test(">", async () => {
-  let f = filterFn([">", "level", 3]);
-  assert(f(0, { props: { level: 4 } }));
-  assert(!f(0, { props: { level: 3 } }));
+  f = filterFn([">", "level", 3]);
+  assert(f(0, { ...emptyFeature, props: { level: 4 } }));
+  assert(!f(0, { ...emptyFeature, props: { level: 3 } }));
 });
 test(">=", async () => {
-  let f = filterFn([">=", "level", 3]);
-  assert(f(0, { props: { level: 4 } }));
-  assert(f(0, { props: { level: 3 } }));
+  f = filterFn([">=", "level", 3]);
+  assert(f(0, { ...emptyFeature, props: { level: 4 } }));
+  assert(f(0, { ...emptyFeature, props: { level: 3 } }));
 });
 test("in", async () => {
-  let f = filterFn(["in", "type", "foo", "bar"]);
-  assert(f(0, { props: { type: "foo" } }));
-  assert(f(0, { props: { type: "bar" } }));
-  assert(!f(0, { props: { type: "baz" } }));
+  f = filterFn(["in", "type", "foo", "bar"]);
+  assert(f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(f(0, { ...emptyFeature, props: { type: "bar" } }));
+  assert(!f(0, { ...emptyFeature, props: { type: "baz" } }));
 });
 test("!in", async () => {
-  let f = filterFn(["!in", "type", "foo", "bar"]);
-  assert(!f(0, { props: { type: "bar" } }));
-  assert(f(0, { props: { type: "baz" } }));
+  f = filterFn(["!in", "type", "foo", "bar"]);
+  assert(!f(0, { ...emptyFeature, props: { type: "bar" } }));
+  assert(f(0, { ...emptyFeature, props: { type: "baz" } }));
 });
 test("has", async () => {
-  let f = filterFn(["has", "type"]);
-  assert(f(0, { props: { type: "foo" } }));
-  assert(!f(0, { props: {} }));
+  f = filterFn(["has", "type"]);
+  assert(f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(!f(0, { ...emptyFeature, props: {} }));
 });
 test("!has", async () => {
-  let f = filterFn(["!has", "type"]);
-  assert(!f(0, { props: { type: "foo" } }));
-  assert(f(0, { props: {} }));
+  f = filterFn(["!has", "type"]);
+  assert(!f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(f(0, { ...emptyFeature, props: {} }));
 });
 test("!", async () => {
-  let f = filterFn(["!", ["has", "type"]]);
-  assert(!f(0, { props: { type: "foo" } }));
-  assert(f(0, { props: {} }));
+  f = filterFn(["!", ["has", "type"]]);
+  assert(!f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(f(0, { ...emptyFeature, props: {} }));
 });
 test("all", async () => {
-  let f = filterFn(["all", ["==", "building", "yes"], ["==", "type", "foo"]]);
-  assert(!f(0, { props: { building: "yes" } }));
-  assert(!f(0, { props: { type: "foo" } }));
-  assert(f(0, { props: { building: "yes", type: "foo" } }));
+  f = filterFn(["all", ["==", "building", "yes"], ["==", "type", "foo"]]);
+  assert(!f(0, { ...emptyFeature, props: { building: "yes" } }));
+  assert(!f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(f(0, { ...emptyFeature, props: { building: "yes", type: "foo" } }));
 });
 test("any", async () => {
-  let f = filterFn(["any", ["==", "building", "yes"], ["==", "type", "foo"]]);
-  assert(!f(0, { props: {} }));
-  assert(f(0, { props: { building: "yes" } }));
-  assert(f(0, { props: { type: "foo" } }));
-  assert(f(0, { props: { building: "yes", type: "foo" } }));
+  f = filterFn(["any", ["==", "building", "yes"], ["==", "type", "foo"]]);
+  assert(!f(0, { ...emptyFeature, props: {} }));
+  assert(f(0, { ...emptyFeature, props: { building: "yes" } }));
+  assert(f(0, { ...emptyFeature, props: { type: "foo" } }));
+  assert(f(0, { ...emptyFeature, props: { building: "yes", type: "foo" } }));
 });
 
 test("numberFn constant", async () => {
@@ -110,43 +121,43 @@ test("numberFn interpolate", async () => {
 test("numberFn properties", async () => {
   let n = numberFn(["step", ["get", "scalerank"], 0, 1, 2, 3, 4]);
   assert.equal(n.length, 2);
-  assert.equal(n(14, { props: { scalerank: 0 } }), 0);
-  assert.equal(n(14, { props: { scalerank: 1 } }), 2);
-  assert.equal(n(14, { props: { scalerank: 3 } }), 4);
-  assert.equal(n(14, { props: { scalerank: 4 } }), 4);
+  assert.equal(n(14, { ...emptyFeature, props: { scalerank: 0 } }), 0);
+  assert.equal(n(14, { ...emptyFeature, props: { scalerank: 1 } }), 2);
+  assert.equal(n(14, { ...emptyFeature, props: { scalerank: 3 } }), 4);
+  assert.equal(n(14, { ...emptyFeature, props: { scalerank: 4 } }), 4);
 });
 
 test("font", async () => {
   let n = getFont({ "text-font": ["Noto"], "text-size": 14 }, {});
-  assert.equal(n, "14px sans-serif");
+  assert.equal(n(1), "14px sans-serif");
 
   n = getFont({ "text-font": ["Noto"], "text-size": 15 }, {});
-  assert.equal(n, "15px sans-serif");
+  assert.equal(n(1), "15px sans-serif");
 
   n = getFont(
     { "text-font": ["Noto"], "text-size": 15 },
     { Noto: { face: "serif" } }
   );
-  assert.equal(n, "15px serif");
+  assert.equal(n(1), "15px serif");
 
   n = getFont(
     { "text-font": ["Boto", "Noto"], "text-size": 15 },
     { Noto: { face: "serif" }, Boto: { face: "Comic Sans" } }
   );
-  assert.equal(n, "15px Comic Sans, serif");
+  assert.equal(n(1), "15px Comic Sans, serif");
 });
 
 test("font weight and style", async () => {
-  n = getFont(
+  let n = getFont(
     { "text-font": ["Noto"], "text-size": 15 },
     { Noto: { face: "serif", weight: 100 } }
   );
-  assert.equal(n, "100 15px serif");
+  assert.equal(n(1), "100 15px serif");
   n = getFont(
     { "text-font": ["Noto"], "text-size": 15 },
     { Noto: { face: "serif", style: "italic" } }
   );
-  assert.equal(n, "italic 15px serif");
+  assert.equal(n(1), "italic 15px serif");
 });
 
 test("font size fn zoom", async () => {
@@ -176,9 +187,18 @@ test("font size fn zoom props", async () => {
     },
     {}
   );
-  assert.equal(n(14, { props: { scalerank: 0 } }), "0px sans-serif");
-  assert.equal(n(14, { props: { scalerank: 1 } }), "12px sans-serif");
-  assert.equal(n(14, { props: { scalerank: 2 } }), "10px sans-serif");
+  assert.equal(
+    n(14, { ...emptyFeature, props: { scalerank: 0 } }),
+    "0px sans-serif"
+  );
+  assert.equal(
+    n(14, { ...emptyFeature, props: { scalerank: 1 } }),
+    "12px sans-serif"
+  );
+  assert.equal(
+    n(14, { ...emptyFeature, props: { scalerank: 2 } }),
+    "10px sans-serif"
+  );
 });
 
 export default test;

--- a/test/line.test.ts
+++ b/test/line.test.ts
@@ -2,57 +2,56 @@ import assert from "assert";
 import baretest from "baretest";
 import { lineCells, simpleLabel } from "../src/line";
 
-test = baretest("Lines");
+const test = baretest("Lines");
 
 test("simple line labeler", async () => {
-  let mls = [
+  const mls = [
     [
       { x: 0, y: 0 },
       { x: 100, y: 0 },
     ],
   ];
-  let results = simpleLabel(mls, 10, 250, 0);
+  const results = simpleLabel(mls, 10, 250, 0);
   assert.deepEqual(results[0].start, { x: 0, y: 0 });
   assert.deepEqual(results[0].end, { x: 10, y: 0 });
-})
-
+});
 
 test("simple line labeler tolerance", async () => {
-  mls = [
+  const mls = [
     [
       { x: 0, y: 0 },
       { x: 20, y: 0.5 },
       { x: 150, y: 0 },
     ],
   ];
-  results = simpleLabel(mls, 100, 250, 0);
+  const results = simpleLabel(mls, 100, 250, 0);
   assert.equal(results.length, 1);
   assert.deepEqual(results[0].start, { x: 0, y: 0 });
   assert.equal(results[0].end.x > 99, true);
   assert.equal(results[0].end.x < 100, true);
 });
 
-test ("simple line labeler - very gradual angles - multiple labels", async () => {
-  mls = [
+test("simple line labeler - very gradual angles - multiple labels", async () => {
+  const mls = [
     [
       { x: 0, y: 0 },
       { x: 10, y: 0.5 }, // about 2 degrees
       { x: 20, y: 1.5 },
       { x: 30, y: 3.0 },
-    ]
-  ]
-  results = simpleLabel(mls, 10, 250, 0);
+    ],
+  ];
+  const results = simpleLabel(mls, 10, 250, 0);
   assert.equal(results.length, 3);
 });
 
 test("simple line labeler - one candidate, multiple labels based on repeatDistance", async () => {
-  let mls = [
+  const mls = [
     [
       { x: 0, y: 0 },
       { x: 500, y: 0 },
     ],
   ];
-  let results = simpleLabel(mls, 100, 250, 0);
+  const results = simpleLabel(mls, 100, 250, 0);
   assert.equal(results.length, 2);
   assert.deepEqual(results[0].start, { x: 0, y: 0 });
   assert.deepEqual(results[0].end, { x: 100, y: 0 });
@@ -61,18 +60,18 @@ test("simple line labeler - one candidate, multiple labels based on repeatDistan
 });
 
 test("too small", async () => {
-  let mls = [
+  const mls = [
     [
       { x: 0, y: 0 },
       { x: 10, y: 0 },
     ],
   ];
-  let results = simpleLabel(mls, 20, 250, 0);
+  const results = simpleLabel(mls, 20, 250, 0);
   assert.equal(results.length, 0);
 });
 
 test("line cells", async () => {
-  let result = lineCells({ x: 0, y: 0 }, { x: 100, y: 0 }, 20, 5);
+  const result = lineCells({ x: 0, y: 0 }, { x: 100, y: 0 }, 20, 5);
   assert.deepEqual(result, [
     { x: 0, y: 0 },
     { x: 10, y: 0 },

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import baretest from "baretest";
 import { getZoom } from "../src/frontends/static";
 
-test = baretest("Static");
+const test = baretest("Static");
 
 test("basic", async () => {
   assert.equal(getZoom(360, 256), 0);

--- a/test/symbolizer.test.ts
+++ b/test/symbolizer.test.ts
@@ -2,7 +2,7 @@ import { exp, step, linear, cubicBezier } from "../src/symbolizer";
 import assert from "assert";
 import baretest from "baretest";
 
-test = baretest("symbolizer");
+const test = baretest("symbolizer");
 
 test("exp", async () => {
   let result = exp(1.4, [])(5);

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -1,7 +1,7 @@
-import { Zxy, TileSource } from "../src/tilecache";
+import { Zxy, TileSource, Feature } from "../src/tilecache";
 
 export class StubSource implements TileSource {
-  public async get(c: Zxy) {
-    return "foo";
+  public async get(c: Zxy): Promise<Map<string, Feature[]>> {
+    return new Map();
   }
 }

--- a/test/text.test.ts
+++ b/test/text.test.ts
@@ -1,8 +1,8 @@
-import { linebreak, FontSpec, TextSpec } from "../src/text";
 import assert from "assert";
 import baretest from "baretest";
+import { linebreak } from "../src/text";
 
-test = baretest("Text");
+const test = baretest("Text");
 
 test("trivial", async () => {
   let lines = linebreak("foo", 15);

--- a/test/tilecache.test.ts
+++ b/test/tilecache.test.ts
@@ -1,20 +1,14 @@
-import {
-  Zxy,
-  TileCache,
-  TileSource,
-  pointMinDistToPoints,
-  pointMinDistToLines,
-  pointInPolygon,
-  isCCW,
-  isInRing,
-} from "../src/tilecache";
-import { StubSource } from "./test_helpers";
 import assert from "assert";
 import baretest from "baretest";
+import {
+  isCCW,
+  isInRing,
+  pointInPolygon,
+  pointMinDistToLines,
+  pointMinDistToPoints,
+} from "../src/tilecache";
 
-test = baretest("Tilecache");
-
-var cache = new TileCache(new StubSource());
+const test = baretest("Tilecache");
 
 test("basic", async () => {
   // cache.get({z:0,x:0,y:0}).then(f => {

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -1,9 +1,9 @@
 import Point from "@mapbox/point-geometry";
-import { Zxy, TileCache, TileSource } from "../src/tilecache";
-import { wrap, View } from "../src/view";
-import { StubSource } from "./test_helpers";
 import assert from "assert";
 import baretest from "baretest";
+import { TileCache } from "../src/tilecache";
+import { View, wrap } from "../src/view";
+import { StubSource } from "./test_helpers";
 
 let test = baretest("view");
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "paths": {
       "@mapbox/unitbezier": ["./src/types/unitbezier.d.ts"]
-    }
+    },
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
I have added more type definitions - mainly for symbolizers and attributes. (with a bit in `json_style`)

The goal was to remove all use of `any` from `attribute.ts` and `symbolizer.ts`.