### PR TITLE
feat(labeling): implement label deduplication, enabled by default for…

### DIFF
--- a/src/symbolizer.ts
+++ b/src/symbolizer.ts
@@ -929,7 +929,13 @@ export class LineLabelSymbolizer implements LabelSymbolizer {
         ctx.fillStyle = this.fill.get(layout.zoom, feature);
         ctx.fillText(name, 0, 0);
       };
-      labels.push({ anchor: candidate.start, bboxes: bboxes, draw: draw });
+      labels.push({
+        anchor: candidate.start,
+        bboxes: bboxes,
+        draw: draw,
+        deduplicationKey: name,
+        deduplicationDistance: repeatDistance,
+      });
     }
 
     return labels;

--- a/test/labeler.test.ts
+++ b/test/labeler.test.ts
@@ -159,4 +159,36 @@ test("remove an individual label", async () => {
   assert.equal(index.tree.all().length, 0);
 });
 
+test("basic label deduplication", async () => {
+  let index = new Index(1024);
+  let label1 = {
+    anchor: new Point(100, 100),
+    bboxes: [{ minX: 100, minY: 100, maxX: 110, maxY: 110 }],
+    draw: (c) => {},
+    deduplicationKey: "Mulholland Dr.",
+    deduplicationDistance: 100,
+  };
+  index.insert(label1, 1, "abcd");
+
+  let repeated_label = {
+    anchor: new Point(200, 100),
+    bboxes: [{ minX: 200, minY: 100, maxX: 210, maxY: 110 }],
+    draw: (c) => {},
+    deduplicationKey: "Mulholland Dr.",
+    deduplicationDistance: 100,
+  };
+
+  assert.equal(index.deduplicationCollides(repeated_label), false);
+
+  let tooclose_label = {
+    anchor: new Point(199, 100),
+    bboxes: [{ minX: 199, minY: 100, maxX: 210, maxY: 110 }],
+    draw: (c) => {},
+    deduplicationKey: "Mulholland Dr.",
+    deduplicationDistance: 100,
+  };
+
+  assert.equal(index.deduplicationCollides(tooclose_label), true);
+});
+
 export default test;


### PR DESCRIPTION
… LineLabelSymbolizer. [#24]

Enables cross-feature deduplication of labels based on repeatDistance, most useful for non-dissolved road segments that share the same name. Example, see "21st street" labels:
Before:
<img width="984" alt="Screen Shot 2021-10-20 at 6 13 53 PM" src="https://user-images.githubusercontent.com/77501/138077976-cd0ab5dc-3058-4187-a8fd-8f6d2f6f8bb8.png">
After:
<img width="984" alt="Screen Shot 2021-10-20 at 6 14 01 PM" src="https://user-images.githubusercontent.com/77501/138077999-9a077193-ba0f-4610-8468-26fd5aed4a7c.png">

