### PR TITLE
Add public transport to basic style

### DIFF
--- a/src/default_style/dark.ts
+++ b/src/default_style/dark.ts
@@ -33,4 +33,8 @@ export const dark: DefaultStyleParams = {
   naturalLabel: "#4c4c4c",
   roadsLabel: "#C4C4C4",
   poisLabel: "#959393",
+  railway: "#7F84D1",
+  tram: "#CF1718",
+  subway: "#76319E",
+  subwayLabel: "#FAD0D0",
 };

--- a/src/default_style/light.ts
+++ b/src/default_style/light.ts
@@ -33,4 +33,8 @@ export const light: DefaultStyleParams = {
   naturalLabel: "#4B8F14",
   roadsLabel: "#888888",
   poisLabel: "#606060",
+  railway: "#B7876B",
+  tram: "#FC6E56",
+  subway: "#D1CCF9",
+  subwayLabel: "#76319E"
 };

--- a/src/default_style/style.ts
+++ b/src/default_style/style.ts
@@ -50,6 +50,10 @@ export interface DefaultStyleParams {
   naturalLabel: string;
   roadsLabel: string;
   poisLabel: string;
+  railway: string;
+  tram: string;
+  subway: string;
+  subwayLabel: string;
 }
 
 const doShading = (params: DefaultStyleParams, shade: string) => {
@@ -141,7 +145,7 @@ export const paintRules = (
         fill: params.wood,
       }),
       filter: (z, f) => {
-        return f.props.natural == "wood";
+        return f.props.natural == "wood" || f.props.landuse=="forest";
       },
     },
     {
@@ -169,6 +173,37 @@ export const paintRules = (
       }),
     },
     {
+      dataLayer: "transit",
+      symbolizer: new LineSymbolizer({
+        color: params.railway,
+        width: exp(1.4, [
+          [5, 0.5],
+          [14, 1],
+          [16, 2],
+        ]),
+        dash: [3,3]
+      }),
+      filter: (z, f) => {
+        return f.props["railway"] == "rail" && f.props["layer"]<0;
+      },
+    },
+    {
+      dataLayer: "physical_line",
+      symbolizer: new LineSymbolizer({
+        color: params.water,
+        width: exp(1.4, [
+          [5, 1],
+          [15, 2],
+          [16, 3],
+        ]),
+        lineCap: "round",
+        lineJoin: "round"
+      }),
+      filter: (z, f) => {
+        return f.props["waterway"] == "river" || (z > 15 && f.props['waterway']=="stream");
+      },
+    },
+    {
       dataLayer: "natural",
       symbolizer: new PolygonSymbolizer({
         fill: params.sand,
@@ -182,6 +217,20 @@ export const paintRules = (
       symbolizer: new PolygonSymbolizer({
         fill: params.buildings,
       }),
+    },
+    {
+      dataLayer: "transit",
+      symbolizer: new LineSymbolizer({
+        color: params.subway,
+        width: exp(1.4, [
+          [5, 2],
+          [14, 3],
+          [16, 2],
+        ]),
+      }),
+      filter: (z, f) => {
+        return f.props["railway"] == "subway";
+      },
     },
     {
       dataLayer: "roads",
@@ -297,6 +346,34 @@ export const paintRules = (
       }),
       filter: (z, f) => {
         return f.props["pmap:kind"] == "highway";
+      },
+    },
+    {
+      dataLayer: "transit",
+      symbolizer: new LineSymbolizer({
+        color: params.tram,
+        width: exp(1.4, [
+          [5, 0.5],
+          [14, 1],
+          [16, 2],
+        ]),
+      }),
+      filter: (z, f) => {
+        return f.props["railway"] == "tram";
+      },
+    },
+    {
+      dataLayer: "transit",
+      symbolizer: new LineSymbolizer({
+        color: params.railway,
+        width: exp(1.4, [
+          [5, 0.5],
+          [14, 1],
+          [16, 2],
+        ]),
+      }),
+      filter: (z, f) => {
+        return f.props["railway"] == "rail" && (!f.props["layer"] || f.props["layer"]>0);
       },
     },
     {
@@ -480,6 +557,36 @@ export const labelRules = (
         }),
         params.waterLabel
       ),
+    },
+    {
+      dataLayer: "physical_line",
+      symbolizer: languageStack(
+          new LineLabelSymbolizer({
+            label_props: nametags,
+            fill: params.waterLabel,
+            font: "italic 600 12px sans-serif",
+            repeatDistance: 500,
+          }),
+          params.waterLabel,
+      ),
+      filter: (z, f) => {
+        return f.props["waterway"] == "river" || (z > 15 && f.props['waterway']=="stream");
+      },
+    },
+    {
+      dataLayer: "transit",
+      symbolizer: languageStack(
+          new LineLabelSymbolizer({
+            label_props: nametags,
+            fill: params.subwayLabel,
+            stroke: 0.5,
+            font: "italic 600 12px sans-serif",
+          }),
+          params.waterLabel,
+      ),
+      filter: (z, f) => {
+        return f.props["railway"] == "subway";
+      },
     },
     {
       dataLayer: "natural",

--- a/src/default_style/style.ts
+++ b/src/default_style/style.ts
@@ -219,20 +219,6 @@ export const paintRules = (
       }),
     },
     {
-      dataLayer: "transit",
-      symbolizer: new LineSymbolizer({
-        color: params.subway,
-        width: exp(1.4, [
-          [5, 2],
-          [14, 3],
-          [16, 2],
-        ]),
-      }),
-      filter: (z, f) => {
-        return f.props["railway"] == "subway";
-      },
-    },
-    {
       dataLayer: "roads",
       symbolizer: new LineSymbolizer({
         color: params.highwayCasing,
@@ -374,6 +360,20 @@ export const paintRules = (
       }),
       filter: (z, f) => {
         return f.props["railway"] == "rail" && (!f.props["layer"] || f.props["layer"]>0);
+      },
+    },
+    {
+      dataLayer: "transit",
+      symbolizer: new LineSymbolizer({
+        color: params.subway,
+        width: exp(1.4, [
+          [5, 2],
+          [14, 3],
+          [16, 2],
+        ]),
+      }),
+      filter: (z, f) => {
+        return f.props["railway"] == "subway";
       },
     },
     {
@@ -581,11 +581,12 @@ export const labelRules = (
             fill: params.subwayLabel,
             stroke: 0.5,
             font: "italic 600 12px sans-serif",
+            repeatDistance: 800
           }),
-          params.waterLabel,
+          params.subwayLabel,
       ),
       filter: (z, f) => {
-        return f.props["railway"] == "subway";
+        return z<15 && f.props["railway"] == "subway";
       },
     },
     {
@@ -622,6 +623,30 @@ export const labelRules = (
       }),
       filter: (z, f) => {
         return f.props["pmap:kind"] == "highway";
+      },
+    },
+    {
+      dataLayer: "pois",
+      symbolizer: new GroupSymbolizer([
+        new CircleSymbolizer({
+          radius: 3,
+          fill: params.poisLabel,
+          stroke: params.earth,
+          width: 1,
+        }),
+        languageStack(
+            new OffsetTextSymbolizer({
+              label_props: nametags,
+              fill: params.subwayLabel,
+              offsetX: 4,
+              offsetY: 4,
+              font: "300 15px sans-serif",
+            }),
+            params.poisLabel
+        ),
+      ]),
+      filter: (z, f) => {
+        return f.props["railway"] == "station";
       },
     },
     {


### PR DESCRIPTION
This change adds public transport (railways, trams and subways) to map. Railway stations are shown in bigger font size and more distinct colours than other POIs.

Colours of these added features are subject to change - I just choose semi-random colors from LazPaint (image editing program) palette.

Also it would be nice to be able to disable subways at all (outside of styles) to be able to style them according to local habits (specific to each city/subway system). Also - it seems there is [some convention](https://wiki.openstreetmap.org/wiki/Metro_Mapping) to tag metro routes with colors to enable rendering of metro lines by color - e.g. [this one](https://maps.mail.ru/osm/tools/subways/latest/render.html#prague), it would be nice to have color on metro lines (looks like protomaps can use it if colour is in data).

I also added displaying of small rivers (`waterway=river`) and on zoom > 15 even streams.

For better displaying of public transport I have these suggestions on underlaying data changes: 

- include `railway=rail` on zoom < 13 (even zoom=10 - railway lines are major landmarks)
- include railway stations on zoom < 16 (something like zoom=13 makes sense to me)
- include also `railway=halt` (those are [smaller form of railway stations](https://wiki.openstreetmap.org/wiki/Tag:railway%3Dhalt))
- be able to differentiate subway and railway stops (this may be mess in data, not preprocessing)
- bonus point: include tram stops (`railway=tram_stop`) and bus stops (`highway=bus_stop`), but rules are [more comples](https://wiki.openstreetmap.org/wiki/Public_transport)

See screenshots:

![prague-railways-trams-metro](https://user-images.githubusercontent.com/615685/178602489-49ea1440-cd49-4e61-8f52-46f7a951cfaa.png)

![praha-metro-railways-trams-negative](https://user-images.githubusercontent.com/615685/178602671-a4b1b0e6-d473-4861-921e-116ad42a4414.png)

![metro-and-railway-stations](https://user-images.githubusercontent.com/615685/178602687-0b516aea-737d-46e1-8718-72185aa048d0.png)

![stanice-pozitiv](https://user-images.githubusercontent.com/615685/178602704-63207f37-896c-43dd-97a4-da8e1b50f20f.png)

![streams](https://user-images.githubusercontent.com/615685/178602819-2b187c96-7b80-4171-99bc-782f3f740c8f.png)

