### PR TITLE
define base property in text_size when is undefined

### DIFF
--- a/src/compat/json_style.ts
+++ b/src/compat/json_style.ts
@@ -150,6 +150,7 @@ export function getFont(obj: any, fontsubmap: any) {
   } else if (text_size.stops) {
     var base = 1.4;
     if (text_size.base) base = text_size.base;
+    else text_size.base = base;
     let t = numberFn(text_size);
     return (z: number, f?: Feature) => {
       return `${style}${weight}${t(z, f)}px ${fontfaces


### PR DESCRIPTION
This change allows you to create the text_size.base property when it is not defined. With this fix I can parse and style an OpenMaptiles style without errors.